### PR TITLE
Remove option to use jalview with Java Web Start

### DIFF
--- a/RfamWeb/root/components/tools/jalview.tt
+++ b/RfamWeb/root/components/tools/jalview.tt
@@ -21,32 +21,8 @@ alignmentURI = c.uri_for( "/family/$acc/alignment/fasta" );
   View seed alignment for <em>[% acc %]</em> using <a class="ext" href="http://www.jalview.org/">Jalview</a>
 </h1>
 
-<div class="jalview">
-  <applet code="jalview.bin.JalviewLite" 
-          width="780" 
-          height="550"
-          archive="[% c.uri_for( "/shared/jalview/jalviewApplet.jar" ) %]">
-    <param name="file" value="[% c.uri_for( "/family/$acc/alignment/fasta", { 'nseLabels' => nseLabels } ) %]" />
-    <param name="defaultColour" value="Taylor" />
-    <param name="linkLabel_1" value="UniProt" />
-    <param name="linkUrl_1" value="http://www.uniprot.org/uniprot/$SEQUENCE_ID$" />
-    <param name="linkLabel_2" value="Rfam sequence page" />
-    <param name="linkUrl_2" value="[% c.uri_for( '/sequence/$SEQUENCE_ID$' ) %]" />
-    <param name="database" value="rfamseq" />
-    <param name="embedded" value="true" /> 
-    <param name="nojmol" value="true" />
-  </applet>
-</div>
-
 <p>
-  You can also 
-  <strong><a href="http://www.jalview.org/services/launchApp?colour=Taylor&amp;open=[% alignmentURI | uri %]">
-    start Jalview</a></strong> via 
-  <a class="ext" href="http://en.wikipedia.org/wiki/Java_Web_Start">Java Web Start</a>
-</p>
-<p>
-  Both versions of Jalview will enable you to view the sequence alignment interactively,
-  but the Web Start application offers slightly more functionality.
+  Jalview will enable you to view the sequence alignment interactively.
 </p>
 
 <a href="#" onclick="window.close()" class="closer">Close window</a>


### PR DESCRIPTION
Java Web Start is now deprecated so this functionality is not working. Perhaps we will replace with something else but for now, simply link to Jalview.